### PR TITLE
Added TPTP-comment characters to the generated proofs

### DIFF
--- a/src/metis.sml
+++ b/src/metis.sml
@@ -157,7 +157,7 @@ val next_cnf =
 local
   fun display_sep () =
       if notshowing_any () then ()
-      else TextIO.print (nChars #"-" (!Print.lineLength) ^ "\n");
+      else TextIO.print (nChars #"%" (!Print.lineLength) ^ "\n");
 
   fun display_name filename =
       if notshowing "name" then ()
@@ -204,7 +204,7 @@ local
 
   local
     fun display_proof_start filename =
-        TextIO.print ("\nSZS output start CNFRefutation for " ^ filename ^ "\n");
+        TextIO.print ("\n% SZS output start CNFRefutation for " ^ filename ^ "\n");
 
     fun display_proof_body problem proofs =
         let
@@ -235,7 +235,7 @@ local
         end;
 
     fun display_proof_end filename =
-        TextIO.print ("SZS output end CNFRefutation for " ^ filename ^ "\n\n");
+        TextIO.print ("% SZS output end CNFRefutation for " ^ filename ^ "\n\n");
   in
     fun display_proof filename problem proofs =
         if notshowing "proof" then ()
@@ -291,7 +291,7 @@ local
   fun display_status filename status =
       if notshowing "status" then ()
       else
-        TextIO.print ("SZS status " ^ Tptp.toStringStatus status ^
+        TextIO.print ("% SZS status " ^ Tptp.toStringStatus status ^
                       " for " ^ filename ^ "\n");
 
   fun display_problem filename cls =


### PR DESCRIPTION
Running [TPTP4X](http://www.cs.miami.edu/~tptp/TPTP/TR/TPTPTR.shtml#TPTP4X) on the  generated proofs (via `--show proof`) generates an error because there are missing TPTP-comment characters (i.e. the symbol `%`) in some lines. I added the missing `%`'s in this pull request.

CC'ing @jonaprieto.
